### PR TITLE
Create top-level bulk.yml containing the import options

### DIFF
--- a/bulk.yml
+++ b/bulk.yml
@@ -1,0 +1,13 @@
+---
+continue: "true"
+transfer: "ln_s"
+exclude: "clientpath"
+checksum_algorithm: "File-Size-64"
+logprefix: "logs/"
+output: "yaml"
+# Default columns for the regular screens.
+# This may need to be modified in other bulk files.
+columns:
+    - target
+    - path
+    - name

--- a/experimentA/idr0041-experimentA-bulk.yml
+++ b/experimentA/idr0041-experimentA-bulk.yml
@@ -1,7 +1,3 @@
 ---
-include: "../../bulk.yml"
+include: "../bulk.yml"
 path: "idr0041-experimentA-filePaths.tsv"
-columns:
-    - target
-    - path
-    - name


### PR DESCRIPTION
Same proposal as https://github.com/IDR/idr0042-nirschl-wsideeplearning/pull/3, this should  make this study repository completely self-sufficient (i.e. no need for idr-metadata) for the purposes of importing and annotating the data into an IDR server
