### PR TITLE
Regenerate .csv file with all the data imported with correct naming

### DIFF
--- a/scripts/create_annotation.py
+++ b/scripts/create_annotation.py
@@ -23,7 +23,7 @@ assays_file = os.path.join(
     scripts_dir, "..", "experimentA", "idr0041-assays.txt")
 logging.info("Reading %s" % assays_file)
 df = pandas.read_csv(assays_file, sep='\t')
-df = df[df[IMAGEFILEPATH].str.contains('170428_MAD2L1gfpcM11')]
+#df = df[df[IMAGEFILEPATH].str.contains('170428_MAD2L1gfpcM11')]
 
 # Generate the dataset and image name columns
 logging.debug("Generating dataset and image name columns")

--- a/scripts/create_annotation.py
+++ b/scripts/create_annotation.py
@@ -23,7 +23,6 @@ assays_file = os.path.join(
     scripts_dir, "..", "experimentA", "idr0041-assays.txt")
 logging.info("Reading %s" % assays_file)
 df = pandas.read_csv(assays_file, sep='\t')
-#df = df[df[IMAGEFILEPATH].str.contains('170428_MAD2L1gfpcM11')]
 
 # Generate the dataset and image name columns
 logging.debug("Generating dataset and image name columns")


### PR DESCRIPTION
This PR just commits the ``.csv`` file for the full annotation of the ``0041...`` data, with the correct names.

This ``.csv`` file was already tested on idr-testing server and the full annotation was successful.
The ``.py`` file was adjusted for this according to the instructions in https://github.com/IDR/idr0041-cai-mitoticatlas/pull/5#issuecomment-375379101.
Note that the problem with installing ``pandas`` on the idr-testing server was not solved. Instead, the ``pandas`` were installed locally on my Mac and later this branch was fetched to the idr-testing server and the ``.csv`` was only used (not regenerated).

Will open a separate PR for the ``.tsv``.

cc @sbesson 