### PR TITLE
Updates for v1.0.1

### DIFF
--- a/bulk.yml
+++ b/bulk.yml
@@ -5,6 +5,7 @@ exclude: "clientpath"
 checksum_algorithm: "File-Size-64"
 logprefix: "logs/"
 output: "yaml"
+skip: "minmax"
 # Default columns for the regular screens.
 # This may need to be modified in other bulk files.
 columns:

--- a/scripts/make_filePaths_from_original_data.py
+++ b/scripts/make_filePaths_from_original_data.py
@@ -36,40 +36,36 @@ metadata_dir = os.path.dirname(os.path.realpath(__file__))
 filepaths_file = join(metadata_dir, "..", "experimentA",
                       "idr0041-experimentA-filePaths.tsv")
 
-# Delete tsv file to prevent appending
-if os.path.exists(filepaths_file):
-    logging.info("Deleting %s" % filepaths_file)
-    os.remove(filepaths_file)
-
 # List all assay folders found under base directory
-all_assays = [join(BASE_DIRECTORY, x) for x in os.listdir(BASE_DIRECTORY)]
-all_assays = sorted(filter(os.path.isdir, all_assays))
-logging.info("Found %g folders under %s" % (len(all_assays), BASE_DIRECTORY))
+original_folders = [join(BASE_DIRECTORY, x) for x in
+                    os.listdir(BASE_DIRECTORY)]
+original_folders = sorted(filter(os.path.isdir, original_folders))
+logging.info("Found %g folders under %s" % (len(original_folders),
+             BASE_DIRECTORY))
 
 # Loop over subset of assay folders delimited by START and STOP
-assays = all_assays[START - 1:STOP]
-nfiles = 0
-nfolders = 0
-logging.info("Generating %s for %g folders" % (filepaths_file, len(assays)))
-for assay in assays:
-    logging.debug("Finding cells under %s" % assay)
+files = []
+folders = original_folders[START - 1:STOP]
+logging.info("Generating %s for %g folders" % (filepaths_file, len(folders)))
+for folder in folders:
+    logging.debug("Finding cells under %s" % folder)
     # Retrieve individual cell per assays excluding calibration folders
-    cells = [x for x in glob(assay + "/*") if not x.endswith("Calibration")]
+    cells = [x for x in glob(folder + "/*") if not x.endswith("Calibration")]
     for cell in cells:
         for t in IMAGE_TYPES:
-            folder = cell + "/%s/*" % IMAGE_TYPES[t]
-            tifs = sorted([x for x in glob(folder)
+            subfolder = cell + "/%s/*" % IMAGE_TYPES[t]
+            tifs = sorted([x for x in glob(subfolder)
                           if not x.endswith("Thumbs.db")])
             logging.debug("Found %g original files under %s" % (
-                         len(tifs), folder))
-            nfolders = nfolders + 1
-            with open(filepaths_file, 'a') as f:
-                for tif in tifs:
-                    f.write("Dataset:name:%s\t%s\t%s\n" % (
-                            basename(assay) + "_%s" % t,
-                            tif,
-                            basename(cell) + basename(tif)[-10:-4]))
-                    nfiles = nfiles + 1
+                         len(tifs), subfolder))
 
-logging.info("Listed %g files to import, located in %g folders" %
-             (nfiles, nfolders))
+            assay = basename(folder) + "_%s" % t
+            for tif in tifs:
+                imagename = basename(cell) + basename(tif)[-10:-4]
+                files.append((assay, tif, imagename))
+
+logging.info("Listed %g files to import" % len(files))
+
+with open(filepaths_file, 'w') as f:
+    for i in files:
+        f.write("Dataset:name:%s\t%s\t%s\n" % (i[0], i[1], i[2]))

--- a/scripts/make_filePaths_from_original_data.py
+++ b/scripts/make_filePaths_from_original_data.py
@@ -24,7 +24,8 @@ IMAGE_TYPES = {
     'mask': 'masktif',
     'conc': 'conctif',
 }
-CORRECTION_DIRECTORY = "/nfs/bioimage/drop/idr0041-cai-mitoticatlas/20180710-ftp"
+CORRECTION_DIRECTORY = \
+    "/nfs/bioimage/drop/idr0041-cai-mitoticatlas/20180710-ftp"
 
 # Initialize logging and perform minimal directory sanity check
 logging.basicConfig(level=DEBUG)
@@ -51,6 +52,7 @@ logging.info("Found %g correction folders under %s" % (len(correction_folders),
 
 # Loop over subset of assay folders delimited by START and STOP
 files = []
+ncorrections = 0
 folders = original_folders[START - 1:STOP]
 logging.info("Generating %s for %g folders" % (filepaths_file, len(folders)))
 for folder in folders:
@@ -78,6 +80,7 @@ for folder in folders:
                                  assay, basename(cell)))
                 elif len(corrected_tifs) == len(tifs):
                     tifs = corrected_tifs
+                    ncorrections += len(corrected_tifs)
                 else:
                     logging.warn("Mismatching image count for (%s, %s)" % (
                                  assay, basename(cell)))
@@ -86,7 +89,8 @@ for folder in folders:
                 imagename = basename(cell) + basename(tif)[-10:-4]
                 files.append((assay, tif, imagename))
 
-logging.info("Listed %g files to import" % len(files))
+logging.info("Listed %g files to import including %g corrected files" %
+             (len(files), ncorrections))
 
 with open(filepaths_file, 'w') as f:
     for i in files:

--- a/scripts/make_filePaths_from_original_data.py
+++ b/scripts/make_filePaths_from_original_data.py
@@ -61,17 +61,26 @@ for folder in folders:
         for t in IMAGE_TYPES:
             assay = basename(folder) + "_%s" % t
 
-            if assay in correction_folders:
-                logging.debug("%s:%s using images from corrected folder",
-                              assay, basename(cell))
-                subfolder = "%s/%s/%s*" % (
-                    CORRECTION_DIRECTORY, assay, basename(cell))
-            else:
-                subfolder = cell + "/%s/*" % IMAGE_TYPES[t]
+            # Find original files
+            subfolder = cell + "/%s/*" % IMAGE_TYPES[t]
             tifs = sorted([x for x in glob(subfolder)
                            if not x.endswith("Thumbs.db")])
             logging.debug("Found %g original files under %s" % (
                           len(tifs), subfolder))
+
+            if assay in correction_folders:
+                logging.debug("Using images from corrected folder")
+                subfolder = "%s/%s/%s_T*" % (
+                    CORRECTION_DIRECTORY, assay, basename(cell))
+                corrected_tifs = sorted([x for x in glob(subfolder)])
+                if not corrected_tifs:
+                    logging.warn("No corrected image found for (%s, %s)" % (
+                                 assay, basename(cell)))
+                elif len(corrected_tifs) == len(tifs):
+                    tifs = corrected_tifs
+                else:
+                    logging.warn("Mismatching image count for (%s, %s)" % (
+                                 assay, basename(cell)))
 
             for tif in tifs:
                 imagename = basename(cell) + basename(tif)[-10:-4]

--- a/scripts/update_v101.sh
+++ b/scripts/update_v101.sh
@@ -7,6 +7,9 @@
 export omero=/opt/omero/server/OMERO.server/bin/omero
 projectId=404
 
+# Log in to local server
+$omero login demo@localhost
+
 # Delete existing map annotations
 $omero metadata populate --batch 100 --wait 2000 --context deletemap --cfg experimentA/idr0041-experimentA-bulkmap-config.yml Project:$projectId --report
 

--- a/scripts/update_v101.sh
+++ b/scripts/update_v101.sh
@@ -50,7 +50,8 @@ parallel -a commands.txt --jobs 5 --results rslt --joblog log import_image
 rm commands.txt
 
 # Reannotate the project
-#omero metadata populate --batch 100 --wait 2000 --context bulkmap --cfg experimentA/idr0041-experimentA-bulkmap-config.yml Project:404 --report
+$omero metadata populate --report --batch 1000 --file experimentA/idr0041-experimentA-annotation.csv Project:$projectId
+$omero metadata populate --report --batch 100 --wait 2000 --context bulkmap --cfg experimentA/idr0041-experimentA-bulkmap-config.yml Project:$projectId
 
 # Log out
 $omero logout

--- a/scripts/update_v101.sh
+++ b/scripts/update_v101.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Performs atlas updates for version 1.0.1
+# http://www.mitocheck.org/mitotic_cell_atlas/downloads/v1.0.1/
+
+
+export omero=/opt/omero/server/OMERO.server/bin/omero
+projectId=404
+
+# Delete existing map annotations
+$omero metadata populate --batch 100 --wait 2000 --context deletemap --cfg experimentA/idr0041-experimentA-bulkmap-config.yml Project:$projectId --report
+
+# Delete top-level bulk annotation
+fId=$($omero hql --ids-only --limit 1 --style plain "select l.child.id from ProjectAnnotationLink l where l.parent.id=$projectId" | cut -d ',' -f2)
+
+$omero delete FileAnnotation:$fId --report --dry-run
+
+# Delete outdated concentration maps
+datasets=$(grep 201807.*ftp experimentA/idr0041-experimentA-filePaths.tsv | awk -F ' ' '{print $1}' | awk -F 'Dataset:name:' '{print $2}' | uniq)
+
+for dataset in $datasets; do
+    datasetId=$($omero hql --ids-only --limit 1 --style plain "select d.id from Dataset d where d.name='$dataset'" | cut -d ',' -f2)
+    echo " Deleting images of dataset $datasetId"
+    
+    # Delete images under dataset
+    $omero delete Dataset/Image:$datasetId --report --dry-run
+done
+
+# Re-import the images
+
+# Reannotate the project
+#omero metadata populate --batch 100 --wait 2000 --context bulkmap --cfg experimentA/idr0041-experimentA-bulkmap-config.yml Project:404 --report

--- a/scripts/update_v101.sh
+++ b/scripts/update_v101.sh
@@ -16,7 +16,11 @@ $omero metadata populate --batch 100 --wait 2000 --context deletemap --cfg exper
 # Delete top-level bulk annotation
 fId=$($omero hql --ids-only --limit 1 --style plain "select l.child.id from ProjectAnnotationLink l where l.parent.id=$projectId" | cut -d ',' -f2)
 
-$omero delete FileAnnotation:$fId --report --dry-run
+if [[ -z $fId ]]; then
+    echo "No top-level annotation found"
+else
+    $omero delete FileAnnotation:$fId --report
+fi
 
 # Delete outdated concentration maps
 datasets=$(grep 201807.*ftp experimentA/idr0041-experimentA-filePaths.tsv | awk -F ' ' '{print $1}' | awk -F 'Dataset:name:' '{print $2}' | uniq)
@@ -26,7 +30,7 @@ for dataset in $datasets; do
     echo " Deleting images of dataset $datasetId"
     
     # Delete images under dataset
-    $omero delete Dataset/Image:$datasetId --report --dry-run
+    $omero delete Dataset/Image:$datasetId --report
 done
 
 # Re-import the images


### PR DESCRIPTION
Following the initial release of the mitotic cell atlas based on http://www.mitocheck.org/mitotic_cell_atlas/downloads/v1.0/, some incorrect concentration maps have been modified in a new upstream version available at http://www.mitocheck.org/mitotic_cell_atlas/downloads/v1.0.1/

This PR contains the corresponding set of changes to update the resource in IDR:
- the `make_filePaths_from_original_data.py` script is amended to also look for data in correction folders and use the latter if available for each cell of each protein
- the corresponding changes to `idr0041-experimentA-filePaths.tsv` are committed and should correspond to 8920 file changes
- the `minmax` calculation step is skipped at import time
- a new `update_v101.sh` script is supplied with performs the following:
  * delete the annotations on existing images
  * delete the top-level bulk annotation
  * delete the images under the corrected concentration map datasets
  * re-import the new concentration maps in parallel
  * re-annotate the entire study

This script has been run step-wise in `test51` with the aim of being executable directly on `prod51` to perform the update.
In addition to reviewing the sanity of the changes, it should be possible and harmless to re-test the complete execution of `update_v101.sh` on `test51`. The full operation should take about 7h including 6h of re-import. To do so, clone this repository in `test51-omeroreadwrite` and run `bash scripts/update_v101.sh`