### PR TITLE
Add list of primary keys to de-duplicate for idr0041

### DIFF
--- a/experimentA/idr0041-experimentA-bulkmap-config.yml
+++ b/experimentA/idr0041-experimentA-bulkmap-config.yml
@@ -64,3 +64,17 @@ columns:
         - name: Comment [Gene Annotation Comments]
           clientname: Gene Annotation Comments
           include: yes
+
+advanced:
+  ignore_missing_primary_key: yes
+  primary_group_keys:
+    - namespace: openmicroscopy.org/mapr/organism
+      keys:
+      - Organism
+    - namespace: openmicroscopy.org/mapr/cell_line
+      keys:
+      - Cell Line
+    - namespace: openmicroscopy.org/mapr/gene
+      keys:
+      - Gene Identifier
+      - Gene Symbol

--- a/experimentA/idr0041-experimentA-bulkmap-config.yml
+++ b/experimentA/idr0041-experimentA-bulkmap-config.yml
@@ -61,6 +61,10 @@ columns:
         - name: Comment [Gene Symbol]
           clientname: Gene Symbol
           include: yes
+
+  - group:
+      namespace: openmicroscopy.org/mapr/gene/supplementary
+      columns:
         - name: Comment [Gene Annotation Comments]
           clientname: Gene Annotation Comments
           include: yes

--- a/experimentA/idr0041-experimentA-bulkmap-config.yml
+++ b/experimentA/idr0041-experimentA-bulkmap-config.yml
@@ -70,11 +70,11 @@ advanced:
   primary_group_keys:
     - namespace: openmicroscopy.org/mapr/organism
       keys:
-      - Organism
+        - Organism
     - namespace: openmicroscopy.org/mapr/cell_line
       keys:
-      - Cell Line
+        - Cell Line
     - namespace: openmicroscopy.org/mapr/gene
       keys:
-      - Gene Identifier
-      - Gene Symbol
+        - Gene Identifier
+        - Gene Symbol


### PR DESCRIPTION
See https://trello.com/c/PCDPtm0N/17-mapr-duplicate-annotations-for-primary-keys 

The idr0041 submission in IDR has been annotated without this configuration leading to the duplication of map annotations which were expected to be unique across all studies.
This commit add the relevant subset of primary_group_keys to the bulkmap configuration.

The proposed testing workflow on `test52` is the following:

- delete all the MapAnnotations of idr0041 with the primary namespaces
- repopulate the MapAnnotations from the bulk_annotations table for these namespaces
- recache mapr and check that the primary key annotations are not duplicated for this study

/cc @dominikl 